### PR TITLE
chore: fakerとopensearch-aws-sigv4の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "thruster", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
+gem "opensearch-aws-sigv4" # [https://github.com/opensearch-project/opensearch-ruby-aws-sigv4]
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -32,4 +34,6 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  gem "faker" # https://github.com/faker-ruby/faker
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-sigv4 (1.10.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.0)
@@ -93,6 +96,14 @@ GEM
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -129,6 +140,9 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.4)
+    multi_json (1.15.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.1)
       date
       net-protocol
@@ -148,6 +162,12 @@ GEM
       racc (~> 1.4)
     nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
+    opensearch-aws-sigv4 (1.2.1)
+      aws-sigv4 (>= 1)
+      opensearch-ruby (>= 1.0.1)
+    opensearch-ruby (3.4.0)
+      faraday (>= 1.0, < 3)
+      multi_json (>= 1.0)
     ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -275,7 +295,9 @@ PLATFORMS
 DEPENDENCIES
   brakeman
   debug
+  faker
   kamal
+  opensearch-aws-sigv4
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 8.0.1)


### PR DESCRIPTION
# 対応内容
2つのgemを追加しました。

## faker
それっぽいサンプルデータを作成する時に重宝します。
https://github.com/faker-ruby/faker

## opensearch-aws-sigv4
OpenSearchを操作するためのgemになります。
https://github.com/opensearch-project/opensearch-ruby-aws-sigv4